### PR TITLE
Fixes '/account' spec so it behaves correctly

### DIFF
--- a/spec/sinatra_logging_in_and_out_spec.rb
+++ b/spec/sinatra_logging_in_and_out_spec.rb
@@ -82,7 +82,8 @@ describe 'ApplicationController' do
       }
       post '/login', params
       get '/account'
-      expect(last_response.body).to include("<h1>Welcome skittles123</h1>\n      <h3>Your Balance: 1000.0</h3>")
+      expect(last_response.body).to include("<h1>Welcome skittles123</h1>")
+      expect(last_response.body).to include("<h3>Your Balance: 1000.0</h3>")
     end
     
   end


### PR DESCRIPTION
This last test was failing even when the desired HTML was being displayed on the page.  By splitting the expectation into two lines and removing the \n characters in the expected string the test passes when both headings are present with the correct information.